### PR TITLE
Correct dispose of flutter switch widget

### DIFF
--- a/lib/flutter_switch.dart
+++ b/lib/flutter_switch.dart
@@ -56,6 +56,12 @@ class _FlutterSwitchState extends State<FlutterSwitch>
       CurvedAnimation(parent: _animationController, curve: Curves.linear),
     );
   }
+  
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
Hi, first of all, thanks for publishing this package, it is awesome. In a project that I use it, I was getting an exception when I tried to force the widget to rebuilt. The exception was exception: disposed with an active ticker. The solution is to dispose the animation controller, so there you go.