### PR TITLE
add rounded rectangle switch

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,7 +29,6 @@ class _MyHomePageState extends State<MyHomePage> {
   bool status6 = false;
   bool status7 = false;
   bool status8 = false;
-  bool status9 = false;
   bool isSwitchOn = false;
 
   Color _textColor = Colors.black;
@@ -310,17 +309,17 @@ class _MyHomePageState extends State<MyHomePage> {
                       height: 40,
                       width: 100,
                       toggleSize: 40,
-                      value: status9,
+                      value: status8,
                       onToggle: (val) {
                         setState(() {
-                          status9 = val;
+                          status8 = val;
                         });
                       },
                     ),
                     Container(
                       alignment: Alignment.centerRight,
                       child: Text(
-                        "Value: $status9",
+                        "Value: $status8",
                       ),
                     ),
                   ],

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -28,6 +28,8 @@ class _MyHomePageState extends State<MyHomePage> {
   bool status5 = false;
   bool status6 = false;
   bool status7 = false;
+  bool status8 = false;
+  bool status9 = false;
   bool isSwitchOn = false;
 
   Color _textColor = Colors.black;
@@ -297,6 +299,33 @@ class _MyHomePageState extends State<MyHomePage> {
                     ),
                   ],
                 ),
+                SizedBox(height: 10.0),
+                Text("Rounded Rectangle Switch"),
+                SizedBox(height: 10.0),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    FlutterSwitch(
+                      toggleRatio: 1.5,
+                      height: 40,
+                      width: 100,
+                      toggleSize: 40,
+                      value: status9,
+                      onToggle: (val) {
+                        setState(() {
+                          status9 = val;
+                        });
+                      },
+                    ),
+                    Container(
+                      alignment: Alignment.centerRight,
+                      child: Text(
+                        "Value: $status9",
+                      ),
+                    ),
+                  ],
+                ),
+                SizedBox(height: 20.0),
               ],
             ),
           ),

--- a/lib/flutter_switch.dart
+++ b/lib/flutter_switch.dart
@@ -43,6 +43,7 @@ class FlutterSwitch extends StatefulWidget {
     this.inactiveIcon,
     this.duration = const Duration(milliseconds: 200),
     this.disabled = false,
+    this.toggleRatio = 1,
   })  : assert(
             (switchBorder == null || activeSwitchBorder == null) &&
                 (switchBorder == null || inactiveSwitchBorder == null),
@@ -249,6 +250,13 @@ class FlutterSwitch extends StatefulWidget {
   /// Defaults to the value of false.
   final bool disabled;
 
+  /// The toggle will be a rounded rectangle when the value is not 1.
+  ///
+  /// Width = Size * toggleRatio, Height = Size.
+  ///
+  /// Defaults to the value of 1.
+  final double toggleRatio;
+
   @override
   _FlutterSwitchState createState() => _FlutterSwitchState();
 }
@@ -375,11 +383,16 @@ class _FlutterSwitchState extends State<FlutterSwitch>
                       child: Align(
                         alignment: _toggleAnimation.value,
                         child: Container(
-                          width: widget.toggleSize,
+                          width: widget.toggleSize * widget.toggleRatio,
                           height: widget.toggleSize,
                           decoration: BoxDecoration(
-                            shape: BoxShape.circle,
+                            shape: widget.toggleRatio == 1
+                                ? BoxShape.circle
+                                : BoxShape.rectangle,
                             color: _toggleColor,
+                            borderRadius: widget.toggleRatio == 1
+                                ? null
+                                : BorderRadius.circular(widget.borderRadius),
                             border: _toggleBorder,
                           ),
                           child: Container(
@@ -417,6 +430,7 @@ class _FlutterSwitchState extends State<FlutterSwitch>
 
   FontWeight get _activeTextFontWeight =>
       widget.activeTextFontWeight ?? FontWeight.w900;
+
   FontWeight get _inactiveTextFontWeight =>
       widget.inactiveTextFontWeight ?? FontWeight.w900;
 


### PR DESCRIPTION
Hi！I add a property that can make the circle toggle turn to a rounded rectangle.
This code passed all tests, and the example is in the [main.dart] already.
I just did little change for it, so if there is something not enough, please tell me and let me improve it.
Wise I could use my code in my project somedays!